### PR TITLE
"glastopf-runner" => "glastopf-runner.py"

### DIFF
--- a/docs/source/installation/installation_ubuntu.rst
+++ b/docs/source/installation/installation_ubuntu.rst
@@ -55,7 +55,7 @@ Prepare glastopf environment::
 	cd 
 	mkdir myhoneypot
 	cd myhoneypot
-	glastopf-runner
+	glastopf-runner.py
 
 A new default glastopf.cfg has been created in *myhoneypot*, which can be customized as required.
 


### PR DESCRIPTION
Ever so minor - but when I followed these instructions I had to add '.py' to get it to run.
