### PR TITLE
error checking for randomizing virtualdocs

### DIFF
--- a/glastopf/glastopf.py
+++ b/glastopf/glastopf.py
@@ -197,9 +197,15 @@ class GlastopfHoneypot(object):
         
         num_entries = random.randint(1, 10) # number of random entries
 
-        pwd = open(pwd_path, "a")
-        shd = open(shd_path, "a")
-        grp = open(grp_path, "a")
+        try:
+            pwd = open(pwd_path, "a")
+            shd = open(shd_path, "a")
+            grp = open(grp_path, "a")
+        except:
+            # We couldn't open the files
+            logger.info("Couldn't randomize the virtualdocs.")
+            return
+            
         for i in xrange(num_entries):
             # Possible duplication of user id, but very low probability
             user_id = random.randint(1000, 1500)


### PR DESCRIPTION
If glastopf can't open the files for some reason, it just avoids trying to randomize them.
