### PR TITLE
Handle non key=value query in sqli handler

### DIFF
--- a/glastopf/modules/handlers/emulators/sqli.py
+++ b/glastopf/modules/handlers/emulators/sqli.py
@@ -33,13 +33,14 @@ class SQLiEmulator(base_emulator.BaseEmulator):
 
     def handle(self, attack_event):
         payload = ""
+        value = ""
         for value_list in attack_event.http_request.request_query.values():
             value = value_list[0]
             self.ret = self.sqli_c.classify(value)
             if len(self.ret["fingerprint"]) > 0:
                 best_query, best_ratio = self.sqli_c.query_similarity(self.ret["fingerprint"], value.lower())
                 payload = self.sqli_c.token_map[best_query]
-        if payload["resp"]:
+        if payload and payload["resp"]:
             attack_event.http_request.set_raw_response(payload["resp"])
         else:
             response = self.sql_response.get_response("mysql_error").content


### PR DESCRIPTION
these return Internal Server Error

payload part:
http://localhost/test.php?SELECT request_url FROM events WHERE pattern

  File "/usr/local/lib/python2.7/site-packages/Glastopf-3.0.9_dev-py2.7.egg/glastopf/modules/handlers/emulators/sqli.py", line 44, in handle
    if payload["resp"]:
TypeError: string indices must be integers, not str

value part:
http://localhost/test.phpSELECT request_url FROM events WHERE pattern

  File "/usr/local/lib/python2.7/site-packages/Glastopf-3.0.9_dev-py2.7.egg/glastopf/modules/handlers/emulators/sqli.py", line 48, in handle
    payload_response = re.sub("PAYLOAD", value, response)
UnboundLocalError: local variable 'value' referenced before assignment
