### PR TITLE
Replace 'í' with html code in phpMyAdmin/translators.html

### DIFF
--- a/glastopf/modules/handlers/emulators/data/server_files/phpMyAdmin/translators.html
+++ b/glastopf/modules/handlers/emulators/data/server_files/phpMyAdmin/translators.html
@@ -500,7 +500,7 @@
     <td>Tatarish</td>
     <td>
         <a href="mailto:amichauer <at> gmx <dot> de?subject=[phpMyAdmin translation] Feedback&amp;body=Before you contact our translator,  please note%3A%0A%0A - Each language file is included in this distribution. The translator won%27t send you any translations.%0A - There are only a few localized documentations yet.%0A - The translator won%27t provide any type of e-mail support.%0A%0AIf you have any questions about configuring or using phpMyAdmin%2C please use our support forum or the users email list.%0A%0A-------------------------------------------------------%0A%0ADear translator%3A just ignore this mail. I haven%27t read the text above and just submitted the mail as my client displayed it..." onclick="return PMA_notice('Tatarish');">
-            Albert Fazlí
+            Albert Fazl&iacute;
         </a>
     </td>
 </tr>


### PR DESCRIPTION
because utf8 codec can not decode byte 0xed 'í'

this prevents
 2013-09-13 14:59:01,838 (glastopf.glastopf) 127.0.0.1 requested GET /phpMyAdmin/translators.html on localhost
Traceback (most recent call last):
  File "/usr/local/lib64/python2.7/site-packages/gevent/wsgi.py", line 114, in handle
    result = self.server.application(env, self.start_response)
  File "/usr/local/lib/python2.7/site-packages/Glastopf-3.0.9_dev-py2.7.egg/glastopf/wsgi_wrapper.py", line 51, in application
    res_webob.text = unicode(body)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xed in position 43384: invalid continuation byte
<WSGIServer fileno=4 address=0.0.0.0:80>: Failed to handle request:
  request = <http_request "GET /phpMyAdmin/translators.html HTTP/1.1" 127.0.0.1:44556>
  application = <bound method GlastopfWSGI.application of <glastopf.wsgi_wrapper.GlastopfWSGI object at 0x284ed90>>
