### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:trusty
+MAINTAINER Lukas Rist <glaslos@gmail.com>
+
+
+## setup APT
+RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse' /etc/apt/sources.list
+RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse' /etc/apt/sources.list
+RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty-backports main restricted universe multiverse' /etc/apt/sources.list
+RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse' /etc/apt/sources.list
+RUN apt-get update
+ENV DEBIAN_FRONTEND noninteractive
+
+
+## Install dependencies
+RUN apt-get install -y python2.7 python-openssl python-gevent libevent-dev python2.7-dev build-essential make
+RUN apt-get install -y python-chardet python-requests python-sqlalchemy python-lxml
+RUN apt-get install -y python-beautifulsoup mongodb python-pip python-dev python-setuptools
+RUN apt-get install -y g++ git php5 php5-dev liblapack-dev gfortran libmysqlclient-dev
+RUN apt-get install -y libxml2-dev libxslt-dev
+RUN pip install --upgrade distribute
+
+
+## Install and configure the PHP sandbox
+RUN git clone git://github.com/glastopf/BFR.git /opt/BFR
+RUN cd /opt/BFR && phpize && ./configure --enable-bfr && make && sudo make install
+RUN for i in $(find / -type f -name php.ini); do sed -i "/[PHP]/azend_extension=$(find /usr/lib/php5 -type f -name bfr.so)" $i; done
+
+
+## Install glastopf from latest sources
+RUN git clone https://github.com/glastopf/glastopf.git /opt/glastopf
+RUN cd /opt/glastopf && python setup.py install
+
+
+## Configuration
+RUN mkdir /opt/myhoneypot
+
+
+# Clean up when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+EXPOSE 80
+WORKDIR /opt/myhoneypot
+CMD ["glastopf-runner"]
+

--- a/docs/source/installation/installation_docker.rst
+++ b/docs/source/installation/installation_docker.rst
@@ -1,0 +1,49 @@
+Glastopf Installation - Docker
+------------------------------
+| 
+| 
+
+Prerequisites
+=============
+|
+
+A server with `Docker <https://www.docker.io/>`_ installed
+
+| 
+
+Build the Docker container image
+================================
+|
+
+    docker build --rm --tag glastopf .
+
+|
+
+Running the Docker container
+============================
+|
+
+    mkdir myhoneypot1
+
+    docker run --detach --publish 80:80 --volume myhoneypot1:/opt/myhoneypot glastopf
+
+A new default glastopf.cfg has been created in *myhoneypot1*, which can be customized as required.
+
+| 
+
+
+Testing the Honeypot
+====================
+|
+
+Use your web browser to visit your honeypot. You should see the following output on your command line::
+
+	2013-03-14 08:34:08,129 (glastopf.glastopf) Initializing Glastopf using "/opt/myhoneypot" as work directory.
+	2013-03-14 08:34:08,130 (glastopf.glastopf) Connecting to main database with: sqlite:///db/glastopf.db
+	2013-03-14 08:34:08,152 (glastopf.modules.reporting.auxiliary.log_hpfeeds) Connecting to feed broker.
+	2013-03-14 08:34:08,227 (glastopf.modules.reporting.auxiliary.log_hpfeeds) Connected to hpfeed broker.
+	2013-03-14 08:34:11,265 (glastopf.glastopf) Glastopf started and privileges dropped.
+	2013-03-14 08:34:32,853 (glastopf.glastopf) 192.168.10.85 requested GET / on 192.168.10.102
+	2013-03-14 08:34:32,960 (glastopf.glastopf) 192.168.10.85 requested GET /style.css on 192.168.10.102
+	2013-03-14 08:34:33,021 (glastopf.glastopf) 192.168.10.85 requested GET /favicon.ico on 192.168.10.102
+


### PR DESCRIPTION
Here's a `Dockerfile` for building a [Docker](https://www.docker.io/) container image that can easily be used to run glastopf.

Furthermore if you decide to publish the built docker container image on the [Docker index](https://index.docker.io/), then running glastopf will be just a one-liner. No more how-to-install-dependencies for new comers.

See [the one](https://index.docker.io/u/tomdesinto/glastopf/) I've published.

If you don't know Docker, it can easily be installed on Ubuntu 14.04 with `sudo apt-get install docker.io`. Complete install instructions are [here](http://docs.docker.io/installation/ubuntulinux/#ubuntu-trusty-1404-lts-64-bit).

Also more and more hosting companies are offering images with a Linux system having Docker pre-installed and ready to go ([Amazon EC2](http://docs.docker.io/installation/amazon/), [DigitalOcean](https://www.digitalocean.com/community/articles/how-to-use-the-digitalocean-docker-application))
