### PR TITLE
Use only dork db when database is set to False in config

### DIFF
--- a/glastopf/modules/handlers/emulators/dork_list/dork_page_generator.py
+++ b/glastopf/modules/handlers/emulators/dork_list/dork_page_generator.py
@@ -46,6 +46,7 @@ class DorkPageGenerator(object):
                  pages_dir=None,
                  mnem_service_instance=None):
         self.database = database_instance
+        self.conf_parser = conf_parser
         if not pages_dir:
             self.pages_path = os.path.join(data_dir, 'dork_pages')
         else:
@@ -78,7 +79,10 @@ class DorkPageGenerator(object):
         line_list = self.prepare_text()
         shuffle(line_list)
 
-        inurl_list = self.database.select_data()
+        if self.conf_parser.getboolean("main-database", "enabled"):
+            inurl_list = self.database.select_data()
+        else:
+            inurl_list = self.database.get_dork_list('inurl')
         shuffle(inurl_list)
         #get data from dorkdb if the live database does not have enough
         if len(inurl_list) < INURL_MIN_SIZE:

--- a/glastopf/testing/test_dork_list.py
+++ b/glastopf/testing/test_dork_list.py
@@ -33,7 +33,7 @@ from glastopf.modules.handlers.emulators.dork_list import database_sqla
 from glastopf.modules.events import attack
 
 from sqlalchemy import create_engine
-
+from ConfigParser import ConfigParser
 
 class TestEmulatorDorkList(unittest.TestCase):
     """Tests the honeypots vulnerable string selection.
@@ -42,6 +42,9 @@ class TestEmulatorDorkList(unittest.TestCase):
     with data a needed."""
 
     def setUp(self):
+        self.config= ConfigParser()
+        self.config.add_section('main-database')
+        self.config.set('main-database', 'enabled', "True")
         self.workdir = tempfile.mkdtemp()
         self.datadir = os.path.join(self.workdir, 'data')
         GlastopfHoneypot.prepare_environment(self.workdir)
@@ -68,7 +71,7 @@ class TestEmulatorDorkList(unittest.TestCase):
             raise Exception("Unsupported database type: {0}".format(dbtype))
         reduced_dorks_file = os.path.join(os.path.split(os.path.abspath(__file__))[0], 'data/dorks_reduced.txt')
         file_processor = DorkFileProcessor(db, dorks_file=reduced_dorks_file)
-        dork_generator = DorkPageGenerator(db, file_processor, self.datadir)
+        dork_generator = DorkPageGenerator(db, file_processor, self.datadir, conf_parser=self.config)
         return db, engine, dork_generator
 
     def test_db_select_sqlalchemy(self):


### PR DESCRIPTION
Hi,

this would be problem, when user deletes dork database, or when db is not created yet, because table events won't exist.

OperationalError: (OperationalError) no such table: events u'SELECT request_url FROM events WHERE pattern = ?' ('rfi',)
<Greenlet at 0x1c1fa50: <bound method DorkPageGenerator.regular_generate_dork of <glastopf.modules.handlers.emulators.dork_list.dork_page_generator.DorkPageGenerator object at 0x1c13350>>(30)> failed with OperationalError