### PR TITLE
Fixing a path traversal vuln. in the file_server emulator

### DIFF
--- a/glastopf/modules/handlers/emulators/file_server.py
+++ b/glastopf/modules/handlers/emulators/file_server.py
@@ -30,7 +30,8 @@ class FileServer(base_emulator.BaseEmulator):
         if request_file == "":
             request_file = "index.html"
         response = ''
-        if os.path.isfile(os.path.join(server_path, request_file)):
+        full_file_path = os.path.abspath(os.path.join(server_path, request_file))
+        if full_file_path.startswith(self.data_dir) and os.path.isfile(full_file_path):
             with open(os.path.join(server_path, request_file), 'r') as f:
                 response += f.read()
         #response with no content-type header


### PR DESCRIPTION
Unsanitized file path lead to a path traversal vulnerability in the file_server emulator allowing glastopf to read arbitrary files including configuration and the database file.