### PR TITLE
Fixing path checking in classification/request.py

### DIFF
--- a/glastopf/modules/classification/request.py
+++ b/glastopf/modules/classification/request.py
@@ -84,7 +84,8 @@ class Classifier(object):
     def file_exists(self, http_request):
         request_path = urlparse.urlparse(http_request.path).path
         requested_file = request_path.lstrip('/')
-        if os.path.isfile(os.path.join(self.server_files_path, requested_file)):
+        full_file_path = os.path.abspath(os.path.join(self.server_files_path, requested_file))
+        if full_file_path.startswith(self.data_dir) and os.path.isfile(full_file_path):
             return True
         return False
 

--- a/glastopf/modules/handlers/emulators/file_server.py
+++ b/glastopf/modules/handlers/emulators/file_server.py
@@ -32,7 +32,7 @@ class FileServer(base_emulator.BaseEmulator):
         response = ''
         full_file_path = os.path.abspath(os.path.join(server_path, request_file))
         if full_file_path.startswith(self.data_dir) and os.path.isfile(full_file_path):
-            with open(os.path.join(server_path, request_file), 'r') as f:
+            with open(full_file_path, 'r') as f:
                 response += f.read()
         #response with no content-type header
         attack_event.http_request.set_response(response, headers=())


### PR DESCRIPTION
Analogically to file_server.py and the last PR, there was a possibility of path traversal in file_exists (although without actually retrieving file content).