### PR TITLE
Fixing wrong path in Classifier

### DIFF
--- a/glastopf/modules/classification/request.py
+++ b/glastopf/modules/classification/request.py
@@ -85,7 +85,7 @@ class Classifier(object):
         request_path = urlparse.urlparse(http_request.path).path
         requested_file = request_path.lstrip('/')
         full_file_path = os.path.abspath(os.path.join(self.server_files_path, requested_file))
-        if full_file_path.startswith(self.data_dir) and os.path.isfile(full_file_path):
+        if full_file_path.startswith(self.server_files_path) and os.path.isfile(full_file_path):
             return True
         return False
 


### PR DESCRIPTION
Unfortunately the former PR contained a bug resulting in an exception on request handling, this PR should fix this.

BTW, would it be possible to fix Travis tests? I've tried to take a look but have no idea what causes failed builds (only that it's something with Zend linking in BFR) :/