### PR TITLE
Make TCP logstash work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
  - "sudo apt-get -qq install python-dev gfortran"
  - "sudo apt-get install -y -q libxml2"
  - "sudo apt-get install dnsutils"
- - "sudo service mongod start"
+ - "sudo service mongod restart"
 # Dependencies for the php sandbox
  - "sudo apt-get -qq install php7.0 php7.0-dev"
 # Install hpfeeds

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
  - "sudo apt-get -qq install python-dev gfortran"
  - "sudo apt-get install -y -q libxml2"
  - "sudo apt-get install dnsutils"
- - "sudo service mongodb start"
+ - "sudo service mongod start"
 # Dependencies for the php sandbox
  - "sudo apt-get -qq install php7.0 php7.0-dev"
 # Install hpfeeds

--- a/glastopf/modules/reporting/auxiliary/log_logstash.py
+++ b/glastopf/modules/reporting/auxiliary/log_logstash.py
@@ -46,9 +46,9 @@ class LogLogStash(BaseLogger):
                                                             password=self.password,
                                                             exchange=self.exchange)
         elif self.handler == 'TCP':
-            logstash_handler = logstash.LogstashHandler(self.host, self.port, version=1)
+            logstash_handler = logstash.TCPLogstashHandler(self.host, self.port, version=1)
         elif self.handler == "UDP":
-            logstash_handler = logstash.LogstashHandler(self.host, self.port, version=1)
+            logstash_handler = logstash.UDPLogstashHandler(self.host, self.port, version=1)
 
         self.attack_logger = logging.getLogger('python-logstash-handler')
         self.attack_logger.setLevel(logging.INFO)

--- a/glastopf/modules/reporting/auxiliary/log_logstash.py
+++ b/glastopf/modules/reporting/auxiliary/log_logstash.py
@@ -64,6 +64,17 @@ class LogLogStash(BaseLogger):
                       'method': attack_event.http_request.request_verb,
                       'url': attack_event.http_request.request_url,
                   }
-        self.attack_logger.info(message)
+
+        extra = {
+            "pattern":     attack_event.matched_pattern,
+            "source_addr": attack_event.source_addr[0],
+            "source_port": attack_event.source_addr[1],
+            "sensor_addr": attack_event.sensor_addr[0],
+            "sensor_port": attack_event.sensor_addr[1],
+            "method":      attack_event.http_request.request_verb,
+            "url":         attack_event.http_request.request_url,
+        }
+
+        self.attack_logger.info(message, extra = extra)
 
 


### PR DESCRIPTION
Currently, logstash.LogstashHandler is an alias for UDPLogstashHandler - thus, handler TCP is ignored, and glastopf always uses UDP logstash.  This change makes it work properly.