### PR TITLE
Listening on multiple http and ssl ports

### DIFF
--- a/bin/glastopf-runner
+++ b/bin/glastopf-runner
@@ -9,6 +9,8 @@ import argparse
 
 from gevent.wsgi import WSGIServer
 import gevent
+from OpenSSL import crypto
+import random
 
 import glastopf
 from glastopf.wsgi_wrapper import GlastopfWSGI
@@ -93,6 +95,29 @@ if __name__ == '__main__':
             'keyfile': conf_parser.get("ssl", "keyfile"),
             'ciphers': 'AES256',
         }
+        # create ssl certificate if none is present.
+        if (ssl['certfile']) and (ssl['keyfile']):
+            if (not os.path.exists(args.workdir+'/'+ssl['certfile'])) or (not os.path.exists(args.workdir+'/'+ssl['keyfile'])):
+                logger.error("SSL keys do not exist, creating new ssl keys.")
+                client_key = crypto.PKey()
+                client_key.generate_key(crypto.TYPE_RSA, 2048)
+                client_cert = crypto.X509()
+                client_cert.set_version(2)
+                client_subj = client_cert.get_subject()
+                client_subj.CN = "localhost"
+                client_cert.set_serial_number(random.randint(50000000, 100000000))
+                client_cert.gmtime_adj_notBefore(0)
+                client_cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+                client_cert.set_issuer(client_cert.get_subject())
+                client_cert.set_pubkey(client_key)
+                client_cert.sign(client_key, 'sha256')
+
+                with open(ssl['certfile'], "wt") as f:
+                    f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, client_cert))
+                with open(ssl['keyfile'], "wt") as f:
+                    f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, client_key))
+        else:
+            logger.error("Glastopf SSL config broken. Check SSL config section.")
 
     honeypot = GlastopfHoneypot(work_dir=args.workdir)
     wsgi_wrapper = GlastopfWSGI(honeypot)

--- a/bin/glastopf-runner
+++ b/bin/glastopf-runner
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         ssl = {
             'certfile': conf_parser.get("ssl", "certfile"),
             'keyfile': conf_parser.get("ssl", "keyfile"),
-            'ciphers': 'RC4',
+            'ciphers': 'AES256',
         }
 
 

--- a/bin/glastopf-runner
+++ b/bin/glastopf-runner
@@ -79,6 +79,8 @@ if __name__ == '__main__':
 
     host = conf_parser.get("webserver", "host")
     ports = conf_parser.get('webserver', 'port').split(',')
+    ssl_ports = conf_parser.get('ssl', 'port').split(',')
+
     if conf_parser.get("ssl", "enabled"):
         ssl = {
             'certfile': conf_parser.get("ssl", "certfile"),
@@ -86,20 +88,18 @@ if __name__ == '__main__':
             'ciphers': 'AES256',
         }
 
-
     honeypot = GlastopfHoneypot(work_dir=args.workdir)
     wsgi_wrapper = GlastopfWSGI(honeypot)
 
     try:
         workers = []
         if conf_parser.get("ssl", "enabled") == "True":
-            for port in ports:
+            for port in ssl_ports:
                 server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None, **ssl)
                 workers.append(gevent.Greenlet(server.start()))
-        else:
-            for port in ports:
-                server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None)
-                workers.append(gevent.Greenlet(server.start()))
+        for port in ports:
+            server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None)
+            workers.append(gevent.Greenlet(server.start()))
         # start background worker and drop privs
         workers.extend(honeypot.start_background_workers())
         gevent.joinall(workers, raise_error=True)

--- a/bin/glastopf-runner
+++ b/bin/glastopf-runner
@@ -78,8 +78,14 @@ if __name__ == '__main__':
     setup_logging(logconsole, logfile, args.verbose, args.workdir)
 
     host = conf_parser.get("webserver", "host")
-    ports = conf_parser.get('webserver', 'port').split(',')
-    ssl_ports = conf_parser.get('ssl', 'port').split(',')
+
+    ports=[]
+    if conf_parser.get('webserver', 'port') and conf_parser.get('webserver', 'port')!='' :
+        ports = map(int, conf_parser.get('webserver', 'port').split(','))
+    ssl_ports=[]
+    if conf_parser.has_option('ssl','port') and conf_parser.get('ssl', 'port')!='':
+            ssl_ports =  map(int, conf_parser.get('ssl', 'port').split(','))
+
 
     if conf_parser.get("ssl", "enabled"):
         ssl = {
@@ -93,13 +99,32 @@ if __name__ == '__main__':
 
     try:
         workers = []
-        if conf_parser.get("ssl", "enabled") == "True":
+
+        # dedicated ports from ssl section
+        if conf_parser.get("ssl", "enabled") == "True" and len(ssl_ports)>0:
+            # use ports from ssl config selection
             for port in ssl_ports:
-                server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None, **ssl)
+                server = WSGIServer((host, port), wsgi_wrapper.application, log=None, **ssl)
                 workers.append(gevent.Greenlet(server.start()))
-        for port in ports:
-            server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None)
-            workers.append(gevent.Greenlet(server.start()))
+                logger.info("Glastopf listening on ssl port %d " % port)
+            # for http use ports from webserver section
+            for port in ports:
+                server = WSGIServer((host, port), wsgi_wrapper.application, log=None)
+                workers.append(gevent.Greenlet(server.start()))
+                logger.info("Glastopf listening on http port %d " % port)
+        # no dedicated ssl ports, take ports from webserver section and use ssl
+        elif conf_parser.get("ssl", "enabled") == "True" and len(ssl_ports)==0:
+            for port in ports:
+                server = WSGIServer((host, port), wsgi_wrapper.application, log=None, **ssl)
+                workers.append(gevent.Greenlet(server.start()))
+                logger.info("Glastopf listening on ssl port %d " % port)
+        else:
+            # use only ports from webserver section, no ssl
+            for port in ports:
+                server = WSGIServer((host, port), wsgi_wrapper.application, log=None)
+                workers.append(gevent.Greenlet(server.start()))
+                logger.info("Glastopf listening on http port %d " % port)
+
         # start background worker and drop privs
         workers.extend(honeypot.start_background_workers())
         gevent.joinall(workers, raise_error=True)

--- a/bin/glastopf-runner
+++ b/bin/glastopf-runner
@@ -78,8 +78,7 @@ if __name__ == '__main__':
     setup_logging(logconsole, logfile, args.verbose, args.workdir)
 
     host = conf_parser.get("webserver", "host")
-    port = conf_parser.getint("webserver", "port")
-    
+    ports = conf_parser.get('webserver', 'port').split(',')
     if conf_parser.get("ssl", "enabled"):
         ssl = {
             'certfile': conf_parser.get("ssl", "certfile"),
@@ -92,15 +91,19 @@ if __name__ == '__main__':
     wsgi_wrapper = GlastopfWSGI(honeypot)
 
     try:
-        if conf_parser.get("ssl", "enabled") == True:
-            server = WSGIServer((host, port), wsgi_wrapper.application, log=None, **ssl)
+        workers = []
+        if conf_parser.get("ssl", "enabled") == "True":
+            for port in ports:
+                server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None, **ssl)
+                workers.append(gevent.Greenlet(server.start()))
         else:
-            server = WSGIServer((host, port), wsgi_wrapper.application, log=None)
-        wsgi_greenlet = gevent.Greenlet(server.start())
-        #start background worker and drop privs
-        workers = honeypot.start_background_workers()
-        workers.append(wsgi_greenlet)
+            for port in ports:
+                server = WSGIServer((host, int(port)), wsgi_wrapper.application, log=None)
+                workers.append(gevent.Greenlet(server.start()))
+        # start background worker and drop privs
+        workers.extend(honeypot.start_background_workers())
         gevent.joinall(workers, raise_error=True)
+
 
     except KeyboardInterrupt as ex:
         honeypot.stop_background_workers()

--- a/bin/glastopf-runner
+++ b/bin/glastopf-runner
@@ -6,11 +6,11 @@ import os
 from ConfigParser import ConfigParser
 import logging.handlers
 import argparse
+import random
 
 from gevent.wsgi import WSGIServer
 import gevent
 from OpenSSL import crypto
-import random
 
 import glastopf
 from glastopf.wsgi_wrapper import GlastopfWSGI
@@ -46,6 +46,14 @@ def setup_logging(logconsole, logfile, verbose, work_dir):
         file_log.setFormatter(formatter)
         root_logger.addHandler(file_log)
 
+def start_webserver(workers, host, port, wsgi_wrapper, ssl):
+    if ssl:
+        server = WSGIServer((host, port), wsgi_wrapper.application, log=None, **ssl)
+        logger.info("Glastopf listening on ssl port %d " % port)
+    else:
+        server = WSGIServer((host, port), wsgi_wrapper.application, log=None)
+        logger.info("Glastopf listening on http port %d " % port)
+    workers.append(gevent.Greenlet(server.start()))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Glastopf runner')
@@ -81,12 +89,12 @@ if __name__ == '__main__':
 
     host = conf_parser.get("webserver", "host")
 
-    ports=[]
-    if conf_parser.get('webserver', 'port') and conf_parser.get('webserver', 'port')!='' :
+    ports = []
+    if conf_parser.get('webserver', 'port') and conf_parser.get('webserver', 'port') != '':
         ports = map(int, conf_parser.get('webserver', 'port').split(','))
-    ssl_ports=[]
-    if conf_parser.has_option('ssl','port') and conf_parser.get('ssl', 'port')!='':
-            ssl_ports =  map(int, conf_parser.get('ssl', 'port').split(','))
+    ssl_ports = []
+    if conf_parser.has_option('ssl', 'port') and conf_parser.get('ssl', 'port') != '':
+        ssl_ports = map(int, conf_parser.get('ssl', 'port').split(','))
 
 
     if conf_parser.get("ssl", "enabled"):
@@ -97,8 +105,9 @@ if __name__ == '__main__':
         }
         # create ssl certificate if none is present.
         if (ssl['certfile']) and (ssl['keyfile']):
-            if (not os.path.exists(args.workdir+'/'+ssl['certfile'])) or (not os.path.exists(args.workdir+'/'+ssl['keyfile'])):
-                logger.error("SSL keys do not exist, creating new ssl keys.")
+            if (not os.path.exists(os.path.join(args.workdir, ssl['certfile']))) \
+                    or (not os.path.exists(os.path.join(args.workdir, ssl['certfile']))):
+                logger.warning("SSL keys do not exist, creating new ssl keys.")
                 client_key = crypto.PKey()
                 client_key.generate_key(crypto.TYPE_RSA, 2048)
                 client_cert = crypto.X509()
@@ -112,9 +121,9 @@ if __name__ == '__main__':
                 client_cert.set_pubkey(client_key)
                 client_cert.sign(client_key, 'sha256')
 
-                with open(ssl['certfile'], "wt") as f:
+                with open(os.path.join(args.workdir, ssl['certfile']), "wt") as f:
                     f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, client_cert))
-                with open(ssl['keyfile'], "wt") as f:
+                with open(os.path.join(args.workdir, ssl['keyfile']), "wt") as f:
                     f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, client_key))
         else:
             logger.error("Glastopf SSL config broken. Check SSL config section.")
@@ -126,29 +135,21 @@ if __name__ == '__main__':
         workers = []
 
         # dedicated ports from ssl section
-        if conf_parser.get("ssl", "enabled") == "True" and len(ssl_ports)>0:
+        if conf_parser.get("ssl", "enabled") == "True" and len(ssl_ports) > 0:
             # use ports from ssl config selection
             for port in ssl_ports:
-                server = WSGIServer((host, port), wsgi_wrapper.application, log=None, **ssl)
-                workers.append(gevent.Greenlet(server.start()))
-                logger.info("Glastopf listening on ssl port %d " % port)
-            # for http use ports from webserver section
+                start_webserver(workers, host, port, wsgi_wrapper, ssl)
+            # for http use ports from webserver config section
             for port in ports:
-                server = WSGIServer((host, port), wsgi_wrapper.application, log=None)
-                workers.append(gevent.Greenlet(server.start()))
-                logger.info("Glastopf listening on http port %d " % port)
+                start_webserver(workers, host, port, wsgi_wrapper, False)
         # no dedicated ssl ports, take ports from webserver section and use ssl
-        elif conf_parser.get("ssl", "enabled") == "True" and len(ssl_ports)==0:
+        elif conf_parser.get("ssl", "enabled") == "True" and len(ssl_ports) == 0:
             for port in ports:
-                server = WSGIServer((host, port), wsgi_wrapper.application, log=None, **ssl)
-                workers.append(gevent.Greenlet(server.start()))
-                logger.info("Glastopf listening on ssl port %d " % port)
+                start_webserver(workers, host, port, wsgi_wrapper, ssl)
         else:
-            # use only ports from webserver section, no ssl
+            # use only ports from webserver config section, no ssl
             for port in ports:
-                server = WSGIServer((host, port), wsgi_wrapper.application, log=None)
-                workers.append(gevent.Greenlet(server.start()))
-                logger.info("Glastopf listening on http port %d " % port)
+                start_webserver(workers, host, port, wsgi_wrapper, False)
 
         # start background worker and drop privs
         workers.extend(honeypot.start_background_workers())

--- a/glastopf/glastopf.cfg.dist
+++ b/glastopf/glastopf.cfg.dist
@@ -9,7 +9,7 @@ proxy_enabled = False
 enabled = False
 certfile =
 keyfile =
-
+port =
 
 #Generic logging for general monitoring
 [logging]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pylibinjection
 libtaxii>=1.1
 python-logstash
 botocore
+urllib3==1.23


### PR DESCRIPTION
For the [sissden project](https://sissden.eu), we modified glastopf to serve on multiple http and ssl ports. 
The following options are available while ensuring compatibility with old config files. 

a) set the http port in [webserver]/port with a single **or multiple ports**, e.g. `port = 80,8888,8080` => glastopf will run on http ports 80, 8080, 8088

```
[webserver]
host = 0.0.0.0
port = 80,8080,8088
...
```

b) use ssl on the above ports by enabling [ssl] `enabled = True` => glastopf will enable ssl on the above configured http ports 80,8080,8088

```
[webserver]
host = 0.0.0.0
port = 80,8080,8088
...

[ssl]
enabled = True
certfile = ssl/server.crt
keyfile = ssl/server.key
```
c) use distinct ports for ssl by adding the port entry, e.g. 443,8443 to the [ssl] section. The ports 80,8080,8088 from the webserver section will still deliver http unless the port is left empty (== ssl only) => glastopf will run http ports 80,8080,8088 and ssl ports  443,8443

```
[webserver]
host = 0.0.0.0
port = 80,8080,8088
uid = nobody
gid = nogroup
proxy_enabled = False

[ssl]
enabled = True
certfile = ssl/server.crt
keyfile = ssl/server.key
port = 443,8443

```
Like this, glastopf is compatible with old config files but also enables new configs to setup multiple new http/ssl listeners.

Further *glastopf-runner* removes RC4 in SSL as this broke ssl connectivity with contemporary clients and replaced it with AES256. 

Finally, *glastopf-runner* now generates self-signed ssl certificates (issued to localhost) as soon as a path/filename is configured and no certificate-/ keyfile is present. Still works if configured with existing keys, but this enables dockerized operation with new keys generated upon every start (important for large-scale deployments). 
