### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyopenssl
 lxml
 sqlalchemy>=0.8.0
 jinja2
-beautifulsoup>=3.2.0
+beautifulsoup4
 requests>=2.20.0
 cssselect>=0.7.0
 pymongo>=2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ beautifulsoup4
 requests>=2.20.0
 cssselect>=0.7.0
 pymongo>=2.4
-MySQL-python
+mysqlclient
 hpfeeds
 pylibinjection
 libtaxii>=1.1


### PR DESCRIPTION
 Due to this error "You're trying to run a very old release of Beautiful Soup under Python 3. This will not work."<>"Please use Beautiful Soup 4, available through the pip package 'beautifulsoup4'." is necessary to update the dependency on requirements.txt